### PR TITLE
Update README to correct link to OpenAI's Responses API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Apply the same configuration pattern to all other servers by replacing `@cloudin
 
 ## Using Cloudinary's MCP servers with OpenAI Responses API
 
-OpenAI's [Responses API](https://platform.openai.com/docs/guides/responses) allows you to integrate MCP servers directly into your OpenAI API calls, enabling AI models to access Cloudinary's media management capabilities in real-time.
+OpenAI's [Responses API](https://platform.openai.com/docs/api-reference/responses) allows you to integrate MCP servers directly into your OpenAI API calls, enabling AI models to access Cloudinary's media management capabilities in real-time.
 
 ### Setup Overview
 


### PR DESCRIPTION
This fixes the non existing "guides" link which results in Page not found. 

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/8c591625-c1e6-446e-834e-d405c9ac922d" />
